### PR TITLE
WIP: add Core Valid output-data-bridge to docker-compose

### DIFF
--- a/docker-compose/acceptance-tests/docker-compose.yml
+++ b/docker-compose/acceptance-tests/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     image: atmoz/sftp
     restart: always
     environment:
-      SFTP_USERS: gridcapa:gridcapa:::data/core/valid/cgms,data/core/valid/cbcoras,data/core/valid/refprogs,data/core/valid/studypoints,data/core/valid/glsks
+      SFTP_USERS: gridcapa:gridcapa:::data/core/valid/cgms,data/core/valid/cbcoras,data/core/valid/refprogs,data/core/valid/studypoints,data/core/valid/glsks,/data/core/valid/outputs
     volumes:
       - sftp-data:/home/gridcapa/data
     ports:
@@ -110,7 +110,7 @@ services:
     image: delfer/alpine-ftp-server
     restart: always
     environment:
-      USERS: gridcapa|gridcapa|/data/gridcapa/cse/d2cc/cgms /data/gridcapa/cse/d2cc/cracs /data/gridcapa/cse/d2cc/glsks /data/gridcapa/cse/d2cc/ntc /data/gridcapa/cse/d2cc/ntcreds /data/gridcapa/cse/d2cc/targetchs /data/gridcapa/cse/d2cc/vulcanus
+      USERS: gridcapa|gridcapa|/data/gridcapa/cse/d2cc/cgms /data/gridcapa/cse/d2cc/cracs /data/gridcapa/cse/d2cc/glsks /data/gridcapa/cse/d2cc/ntc /data/gridcapa/cse/d2cc/ntcreds /data/gridcapa/cse/d2cc/targetchs /data/gridcapa/cse/d2cc/vulcanus /data/gridcapa/cse/d2cc/outputs
     volumes:
       - ftp-data:/data/gridcapa
     ports:
@@ -176,6 +176,13 @@ services:
       - "5432:5432"
     volumes:
       - cse-postgres-data:/bitnami/postgres
+    networks:
+      - gridcapa
+
+  core-valid-output-data-bridge:
+    image: farao/gridcapa-output-data-bridge:SNAPSHOT
+    volumes:
+      - ../config/core/valid/core-valid-output-data-bridge.yml:/config/application.yml
     networks:
       - gridcapa
 

--- a/docker-compose/config/core/valid/core-valid-output-data-bridge.yml
+++ b/docker-compose/config/core/valid/core-valid-output-data-bridge.yml
@@ -1,0 +1,18 @@
+data-bridge:
+  file-regex: StudyPointResult.csv
+  sources:
+    minio:
+      url: http://minio:9000
+      access-key: gridcapa
+      secret-key: gridcapa
+      bucket: gridcapa
+      base-directory: /CORE/VALID/
+      polling-delay-in-ms: 10000
+  sinks:
+    ftp:
+      active: true
+      host: localhost
+      port: 21
+      username: gridcapa
+      password: gridcapa
+      base-directory: /data/gridcapa/cse/d2cc/cgms


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The results of a Core Valid computation are available in minIO database but not exported to a SFTP.


**What is the new behavior (if this is a feature change)?**
The results of a Core Valid computation are available in minIO database and then exported to a SFTP, thanks to the newly deployed service core-valid-gridcapa-output-databridge.
For more information, see https://github.com/farao-community/gridcapa-output-data-bridge


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No
