### PR TITLE
Fix export and NTC2 import IDCC regex data bridges issue

### DIFF
--- a/docker-compose/cse-export-d2cc/config/data-bridge/cse-export-d2cc-cgm-data-bridge-application.yml
+++ b/docker-compose/cse-export-d2cc/config/data-bridge/cse-export-d2cc-cgm-data-bridge-application.yml
@@ -5,8 +5,8 @@ data-bridge:
   file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(uct|UCT)
   time-validity: hourly
   remote-file-regex:
-    - ".*.zip"
-    - "[0-9]{8}_[0-9]{4}_.*.(uct|UCT)"
+    - ".*Transit.*.zip"
+    - "[0-9]{8}_[0-9]{4}_.*Transit.*.(uct|UCT)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-export-d2cc/config/data-bridge/cse-export-d2cc-crac-data-bridge-application.yml
+++ b/docker-compose/cse-export-d2cc/config/data-bridge/cse-export-d2cc-crac-data-bridge-application.yml
@@ -2,11 +2,11 @@ data-bridge:
   zone-id: "Europe/Paris"
   target-process: CSE_EXPORT_D2CC
   file-type: CRAC
-  file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2}).*.(xml|XML)
+  file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(xml|XML)
   time-validity: hourly
   remote-file-regex:
-    - ".*.zip"
-    - "[0-9]{8}_[0-9]{4}.*.(xml|XML)"
+    - ".*Transit.*.zip"
+    - "[0-9]{8}_[0-9]{4}_.*Transit.*.(xml|XML)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-export-idcc/config/data-bridge/cse-export-idcc-cgm-data-bridge-application.yml
+++ b/docker-compose/cse-export-idcc/config/data-bridge/cse-export-idcc-cgm-data-bridge-application.yml
@@ -2,11 +2,11 @@ data-bridge:
   zone-id: "Europe/Paris"
   target-process: CSE_EXPORT_IDCC
   file-type: CGM
-  file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*Transit*.(uct|UCT)
+  file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(uct|UCT)
   time-validity: hourly
   remote-file-regex:
-    - ".*.zip"
-    - "[0-9]{8}_[0-9]{4}_.*.(uct|UCT)"
+    - ".*Transit.*.zip"
+    - "[0-9]{8}_[0-9]{4}_.*Transit.*.(uct|UCT)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-export-idcc/config/data-bridge/cse-export-idcc-crac-data-bridge-application.yml
+++ b/docker-compose/cse-export-idcc/config/data-bridge/cse-export-idcc-crac-data-bridge-application.yml
@@ -2,11 +2,11 @@ data-bridge:
   zone-id: "Europe/Paris"
   target-process: CSE_EXPORT_IDCC
   file-type: CRAC
-  file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*Transit*.(xml|XML)
+  file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(xml|XML)
   time-validity: hourly
   remote-file-regex:
-    - ".*.zip"
-    - "[0-9]{8}_[0-9]{4}.*.(xml|XML)"
+    - ".*Transit.*.zip"
+    - "[0-9]{8}_[0-9]{4}_.*Transit.*.(xml|XML)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-at-data-bridge-application.yml
+++ b/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-at-data-bridge-application.yml
@@ -4,8 +4,7 @@ data-bridge:
   file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
   time-validity: daily
   remote-file-regex:
-    - ".*.zip"
-    - ".*[0-9]{8}.*.(xml|XML)"
+    - ".*[0-9]{8}.*AT-IT.*.(xml|XML)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-ch-data-bridge-application.yml
+++ b/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-ch-data-bridge-application.yml
@@ -4,8 +4,7 @@ data-bridge:
   file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
   time-validity: daily
   remote-file-regex:
-    - ".*.zip"
-    - ".*[0-9]{8}.*.(xml|XML)"
+    - ".*[0-9]{8}.*CH-IT.*.(xml|XML)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-fr-data-bridge-application.yml
+++ b/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-fr-data-bridge-application.yml
@@ -4,8 +4,7 @@ data-bridge:
   file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
   time-validity: daily
   remote-file-regex:
-    - ".*.zip"
-    - ".*[0-9]{8}.*.(xml|XML)"
+    - ".*[0-9]{8}.*FR-IT.*.(xml|XML)"
   sources:
     ftp:
       active: true

--- a/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-si-data-bridge-application.yml
+++ b/docker-compose/cse-import-idcc/config/data-bridge/cse-idcc-ntc2-si-data-bridge-application.yml
@@ -4,8 +4,7 @@ data-bridge:
   file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
   time-validity: daily
   remote-file-regex:
-    - ".*.zip"
-    - ".*[0-9]{8}.*.(xml|XML)"
+    - ".*[0-9]{8}.*SI-IT.*.(xml|XML)"
   sources:
     ftp:
       active: true

--- a/k8s/cse/export-corner/d2cc/data-bridge/cse-export-d2cc-cgm-data-bridge-configmap.yaml
+++ b/k8s/cse/export-corner/d2cc/data-bridge/cse-export-d2cc-cgm-data-bridge-configmap.yaml
@@ -13,11 +13,11 @@ data:
       zone-id: "Europe/Paris"
       target-process: CSE_EXPORT_D2CC
       file-type: CGM
-      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*Transit*.(uct|UCT)
+      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(uct|UCT)
       time-validity: hourly
       remote-file-regex:
-        - ".*.zip"
-        - "[0-9]{8}_[0-9]{4}_.*.(uct|UCT)"
+        - ".*Transit.*.zip"
+        - "[0-9]{8}_[0-9]{4}_.*Transit.*.(uct|UCT)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/export-corner/d2cc/data-bridge/cse-export-d2cc-crac-data-bridge-configmap.yaml
+++ b/k8s/cse/export-corner/d2cc/data-bridge/cse-export-d2cc-crac-data-bridge-configmap.yaml
@@ -13,11 +13,11 @@ data:
       zone-id: "Europe/Paris"
       target-process: CSE_EXPORT_D2CC
       file-type: CRAC
-      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*Transit*.(xml|XML)
+      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(xml|XML)
       time-validity: hourly
       remote-file-regex:
-        - ".*.zip"
-        - "[0-9]{8}_[0-9]{4}.*.(xml|XML)"
+        - ".*Transit.*.zip"
+        - "[0-9]{8}_[0-9]{4}_.*Transit.*.(xml|XML)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/export-corner/idcc/data-bridge/cse-export-idcc-cgm-data-bridge-configmap.yaml
+++ b/k8s/cse/export-corner/idcc/data-bridge/cse-export-idcc-cgm-data-bridge-configmap.yaml
@@ -13,11 +13,11 @@ data:
       zone-id: "Europe/Paris"
       target-process: CSE_EXPORT_IDCC
       file-type: CGM
-      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*Transit*.(uct|UCT)
+      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(uct|UCT)
       time-validity: hourly
       remote-file-regex:
-        - ".*.zip"
-        - "[0-9]{8}_[0-9]{4}_.*.(uct|UCT)"
+        - ".*Transit.*.zip"
+        - "[0-9]{8}_[0-9]{4}_.*Transit.*.(uct|UCT)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/export-corner/idcc/data-bridge/cse-export-idcc-crac-data-bridge-configmap.yaml
+++ b/k8s/cse/export-corner/idcc/data-bridge/cse-export-idcc-crac-data-bridge-configmap.yaml
@@ -13,11 +13,11 @@ data:
       zone-id: "Europe/Paris"
       target-process: CSE_EXPORT_IDCC
       file-type: CRAC
-      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*Transit*.(xml|XML)
+      file-regex: (?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2})_(?<hour>[0-9]{2})(?<minute>[0-9]{2})_.*.(xml|XML)
       time-validity: hourly
       remote-file-regex:
-        - ".*.zip"
-        - "[0-9]{8}_[0-9]{4}.*.(xml|XML)"
+        - ".*Transit.*.zip"
+        - "[0-9]{8}_[0-9]{4}_.*Transit.*.(xml|XML)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-at-data-bridge-configmap.yaml
+++ b/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-at-data-bridge-configmap.yaml
@@ -16,8 +16,7 @@ data:
       file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
       time-validity: daily
       remote-file-regex:
-        - ".*.zip"
-        - ".*[0-9]{8}.*.(xml|XML)"
+        - ".*[0-9]{8}.*AT-IT.*.(xml|XML)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-ch-data-bridge-configmap.yaml
+++ b/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-ch-data-bridge-configmap.yaml
@@ -16,8 +16,7 @@ data:
       file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
       time-validity: daily
       remote-file-regex:
-        - ".*.zip"
-        - ".*[0-9]{8}.*.(xml|XML)"
+        - ".*[0-9]{8}.*CH-IT.*.(xml|XML)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-fr-data-bridge-configmap.yaml
+++ b/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-fr-data-bridge-configmap.yaml
@@ -16,8 +16,7 @@ data:
       file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
       time-validity: daily
       remote-file-regex:
-        - ".*.zip"
-        - ".*[0-9]{8}.*.(xml|XML)"
+        - ".*[0-9]{8}.*FR-IT.*.(xml|XML)"
       sources:
         ftp:
           active: true

--- a/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-si-data-bridge-configmap.yaml
+++ b/k8s/cse/import-corner/idcc/data-bridge/cse-import-idcc-ntc2-si-data-bridge-configmap.yaml
@@ -16,8 +16,7 @@ data:
       file-regex: .*(?<year>[0-9]{4})(?<month>[0-9]{2})(?<day>[0-9]{2}).*.(xml|XML)
       time-validity: daily
       remote-file-regex:
-        - ".*.zip"
-        - ".*[0-9]{8}.*.(xml|XML)"
+        - ".*[0-9]{8}.*SI-IT.*.(xml|XML)"
       sources:
         ftp:
           active: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
CORESO was facing two issues. First, export corner files ended by _CSE.XXX which was not correctly defined in the file regex. Besides it is better to add Transit naming convention in the remote file regex, otherwise some files that don't have this tag would be uploaded. Second, sometimes it is easy to wrongly upload files between NTC2 (very close naming) and an error that fails the data bridge could occur in a NTC2 file was uploaded n the wrong NC2 folder, by adding a tag in the file-remote regex we avoid this kind of errors.
