### PR TITLE
Fixed MinIO export to FTP for CORE CC

### DIFF
--- a/docker-compose/core-cc/config/core-cc-output-data-bridge.yml
+++ b/docker-compose/core-cc/config/core-cc-output-data-bridge.yml
@@ -6,7 +6,7 @@ data-bridge:
       access-key: gridcapa
       secret-key: gridcapa
       bucket: gridcapa
-      base-directory: /CORE/CC/RAO_OUTPUT_DIR
+      base-directory: /CORE/CC/RAO_OUTPUTS_DIR
       polling-delay-in-ms: 3000
   sinks:
     ftp:


### PR DESCRIPTION
In `docker-compose/core-cc/config/core-cc-output-data-bridge.yml` the Gridcapa output directory for Minio was missing a S in its name so the export to FTP did not work (RAO_OUTPUT_DIR instead of RAO_OUTPUT**S**_DIR).

Now it works! :wink: 