### PR TITLE
Use secrets to store kubeconfig for scale-down-rao jobs

### DIFF
--- a/k8s/overlays/azure-new/dev/rao-auto-scale-down.yaml
+++ b/k8s/overlays/azure-new/dev/rao-auto-scale-down.yaml
@@ -14,5 +14,13 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - kubectl --kubeconfig=.kube/config_new -n gridcapa-d scale --replicas=1 deployment/rao-runner
+                - kubectl --kubeconfig=/.kube/config -n gridcapa-t scale --replicas=1 deployment/rao-runner
+              volumeMounts:
+                - mountPath: /.kube/config
+                  subPath: config_new
+                  name: farao-azure-kubeconfig
+          volumes:
+            - name: farao-azure-kubeconfig
+              secret:
+                secretName: farao-azure-kubeconfig
           restartPolicy: OnFailure

--- a/k8s/overlays/azure-new/test/rao-auto-scale-down.yaml
+++ b/k8s/overlays/azure-new/test/rao-auto-scale-down.yaml
@@ -14,5 +14,13 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - kubectl --kubeconfig=.kube/config_new -n gridcapa-t scale --replicas=1 deployment/rao-runner
+                - kubectl --kubeconfig=/.kube/config -n gridcapa-t scale --replicas=1 deployment/rao-runner
+              volumeMounts:
+                - mountPath: /.kube/config
+                  subPath: config_new
+                  name: farao-azure-kubeconfig
+          volumes:
+            - name: farao-azure-kubeconfig
+              secret:
+                secretName: farao-azure-kubeconfig
           restartPolicy: OnFailure


### PR DESCRIPTION
Secrets have already been created for Azure-new Dev & Test using following command:
```
kubectl create secret generic farao-azure-kubeconfig --from-file=./.kube/config_new
```

-----

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
