### PR TITLE
Use private DockerHub image for RAO runner with XPRESS

### DIFF
--- a/k8s/overlays/azure-new/dev/kustomization.yaml
+++ b/k8s/overlays/azure-new/dev/kustomization.yaml
@@ -56,7 +56,7 @@ configMapGenerator:
     envs: [env.properties]
 
 patches:
-  # Add ImagePullSecrets to retrieve private gridcapa-rao-runner-with-xpress from p2rte
+  # Add ImagePullSecrets to retrieve private gridcapa-rao-runner-with-xpress from dockerhub
   # Adapt requests/limits
   - patch: |-
       kind: Deployment
@@ -76,7 +76,7 @@ patches:
                     cpu: "16.0"
                     memory: "64Gi"
             imagePullSecrets:
-              - name: p2rte-acr-secret
+              - name: dockerhub-acr-secret
 images:
   - name: apps-metadata-server
     newName: docker.io/bitnami/apache
@@ -106,7 +106,7 @@ images:
     newName: docker.io/gridsuite/config-server
     newTag: 0.15.0
   - name: gridcapa-rao-runner
-    newName: p2rte.azurecr.io/farao/gridcapa-rao-runner-with-xpress
+    newName: docker.io/farao/gridcapa-rao-runner-with-xpress
     newTag: v1.16.1
   - name: gridcapa-app
     newName: docker.io/farao/gridcapa-app

--- a/k8s/overlays/azure-new/test/kustomization.yaml
+++ b/k8s/overlays/azure-new/test/kustomization.yaml
@@ -48,7 +48,7 @@ configMapGenerator:
 patches:
   # - Scale-up to 4 instances
   # - Adapt requests/limits
-  # - Add ImagePullSecrets to retrieve private gridcapa-rao-runner-with-xpress from p2rte
+  # - Add ImagePullSecrets to retrieve private gridcapa-rao-runner-with-xpress from dockerhub
   - patch: |-
       kind: Deployment
       apiVersion: apps/v1
@@ -68,7 +68,7 @@ patches:
                     cpu: "16.0"
                     memory: "64Gi"
             imagePullSecrets:
-              - name: p2rte-acr-secret
+              - name: dockerhub-acr-secret
 # Scale-up to 4 instances and adapt CSE runner itools config
   - patch: |-
       kind: Deployment
@@ -234,7 +234,7 @@ images:
     newName: docker.io/gridsuite/config-server
     newTag: 0.15.0
   - name: gridcapa-rao-runner
-    newName: p2rte.azurecr.io/farao/gridcapa-rao-runner-with-xpress
+    newName: docker.io/farao/gridcapa-rao-runner-with-xpress
     newTag: v1.16.1
   - name: gridcapa-app
     newName: docker.io/farao/gridcapa-app

--- a/k8s/overlays/azure/test/kustomization.yaml
+++ b/k8s/overlays/azure/test/kustomization.yaml
@@ -48,7 +48,7 @@ configMapGenerator:
 patches:
   # - Scale-up to 4 instances
   # - Adapt requests/limits
-  # - Add ImagePullSecrets to retrieve private gridcapa-rao-runner-with-xpress from p2rte
+  # - Add ImagePullSecrets to retrieve private gridcapa-rao-runner-with-xpress from dockerhub
   - patch: |-
       kind: Deployment
       apiVersion: apps/v1
@@ -68,7 +68,7 @@ patches:
                     cpu: "16.0"
                     memory: "64Gi"
             imagePullSecrets:
-              - name: p2rte-acr-secret
+              - name: dockerhub-acr-secret
   # Scale-up to 4 instances and adapt CSE runner itools config
   - patch: |-
       kind: Deployment
@@ -234,7 +234,7 @@ images:
     newName: docker.io/gridsuite/config-server
     newTag: 0.15.0
   - name: gridcapa-rao-runner
-    newName: p2rte.azurecr.io/farao/gridcapa-rao-runner-with-xpress
+    newName: docker.io/farao/gridcapa-rao-runner-with-xpress
     newTag: v1.16.1
   - name: gridcapa-app
     newName: docker.io/farao/gridcapa-app


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What is the new behavior (if this is a feature change)?**
Deployment on both Azure and CORESO platform now uses DockerHub as source of gridcapa-rao-runner-with-xpress docker image 

