### PR TITLE
Fix rabbitmq vhost

### DIFF
--- a/docker-compose/common/config/rabbitmq.conf
+++ b/docker-compose/common/config/rabbitmq.conf
@@ -1,1 +1,2 @@
 consumer_timeout = 43200000
+default_vhost = gridcapa

--- a/docker-compose/common/config/rao-runner-application.yml
+++ b/docker-compose/common/config/rao-runner-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/core-cc/config/core-cc-adapter-application.yml
+++ b/docker-compose/core-cc/config/core-cc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
   cloud:

--- a/docker-compose/core-cc/config/core-cc-gridcapa-job-launcher.yml
+++ b/docker-compose/core-cc/config/core-cc-gridcapa-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: core-cc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/core-cc/config/core-cc-gridcapa-post-processing.yml
+++ b/docker-compose/core-cc/config/core-cc-gridcapa-post-processing.yml
@@ -7,9 +7,10 @@ spring:
     name: core-cc-gridcapa-post-processing
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/core-cc/config/core-cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/core-cc/config/core-cc-gridcapa-task-manager-application.yml
@@ -14,6 +14,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/core-cc/config/core-cc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/core-cc/config/core-cc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/core-cc/config/core-cc-runner-application.yml
+++ b/docker-compose/core-cc/config/core-cc-runner-application.yml
@@ -8,6 +8,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/core-valid/config/core-valid-adapter-application.yml
+++ b/docker-compose/core-valid/config/core-valid-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
   cloud:

--- a/docker-compose/core-valid/config/core-valid-gridcapa-export-application.yml
+++ b/docker-compose/core-valid/config/core-valid-gridcapa-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/core-valid/config/core-valid-gridcapa-fake-runner.yml
+++ b/docker-compose/core-valid/config/core-valid-gridcapa-fake-runner.yml
@@ -1,9 +1,10 @@
 spring:
   rabbitmq:
-    username: gridcapa
-    password: gridcapa
     host: rabbitmq
     port: 5672
+    username: gridcapa
+    password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/core-valid/config/core-valid-gridcapa-job-launcher.yml
+++ b/docker-compose/core-valid/config/core-valid-gridcapa-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: core-valid-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/core-valid/config/core-valid-gridcapa-task-manager-application.yml
+++ b/docker-compose/core-valid/config/core-valid-gridcapa-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/core-valid/config/core-valid-rao-logs-dispatcher-application.yml
+++ b/docker-compose/core-valid/config/core-valid-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/core-valid/config/core-valid-runner-application.yml
+++ b/docker-compose/core-valid/config/core-valid-runner-application.yml
@@ -8,6 +8,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-adapter-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-job-launcher.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-export-d2cc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-outputs-exporter-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-outputs-exporter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-runner-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-task-manager-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-adapter-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-job-launcher.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-export-idcc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-outputs-exporter-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-outputs-exporter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-runner-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-task-manager-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-adapter-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-export-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-fake-runner.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-fake-runner.yml
@@ -1,9 +1,10 @@
 spring:
   rabbitmq:
-    username: gridcapa
-    password: gridcapa
     host: rabbitmq
     port: 5672
+    username: gridcapa
+    password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-job-launcher.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-import-d2cc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-runner-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-adapter-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-export-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-fake-runner.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-fake-runner.yml
@@ -1,9 +1,10 @@
 spring:
   rabbitmq:
-    username: gridcapa
-    password: gridcapa
     host: rabbitmq
     port: 5672
+    username: gridcapa
+    password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-job-launcher.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-import-ec-d2cc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-runner-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-adapter-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-gridcapa-export-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-gridcapa-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-job-launcher.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-import-ec-idcc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-runner-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-task-manager-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-adapter-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-gridcapa-export-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-gridcapa-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-job-launcher.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-import-idcc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-runner-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-task-manager-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-adapter-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
   cloud:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-gridcapa-job-launcher.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-gridcapa-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-valid-d2cc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-gridcapa-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-publication-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-publication-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
 

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-runner-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-runner-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
   cloud:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-adapter-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-adapter-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
   cloud:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-gridcapa-job-launcher.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-gridcapa-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: cse-valid-idcc-gridcapa-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-gridcapa-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-publication-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-publication-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
 

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-runner-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-runner-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 6000000
   cloud:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-adapter-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-adapter-application.yml
@@ -2,10 +2,11 @@ spring:
   application:
     name: swe-d2cc-adapter
   rabbitmq:
-    username: gridcapa
-    password: gridcapa
     host: rabbitmq
     port: 5672
+    username: gridcapa
+    password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-export-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-job-launcher.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: swe-d2cc-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-runner-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-task-manager-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-adapter-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-adapter-application.yml
@@ -1,9 +1,10 @@
 spring:
   rabbitmq:
-    username: gridcapa
-    password: gridcapa
     host: rabbitmq
     port: 5672
+    username: gridcapa
+    password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-export-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-job-launcher.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: swe-idcc-idcf-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-rao-logs-dispatcher-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-runner-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-task-manager-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-idcc/config/swe-idcc-adapter-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-adapter-application.yml
@@ -1,9 +1,10 @@
 spring:
   rabbitmq:
-    username: gridcapa
-    password: gridcapa
     host: rabbitmq
     port: 5672
+    username: gridcapa
+    password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/swe-idcc/config/swe-idcc-export-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-export-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-idcc/config/swe-idcc-job-launcher.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-job-launcher.yml
@@ -7,9 +7,10 @@ spring:
     name: swe-idcc-job-launcher
   rabbitmq:
     host: rabbitmq
+    port: 5672
     username: gridcapa
     password: gridcapa
-    port: 5672
+    virtual-host: gridcapa
   cloud:
     stream:
       bindings:

--- a/docker-compose/swe-idcc/config/swe-idcc-rao-logs-dispatcher-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-rao-logs-dispatcher-application.yml
@@ -4,6 +4,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/docker-compose/swe-idcc/config/swe-idcc-runner-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-runner-application.yml
@@ -6,6 +6,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
     template:
       reply-timeout: 7200000
   cloud:

--- a/docker-compose/swe-idcc/config/swe-idcc-task-manager-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-task-manager-application.yml
@@ -12,6 +12,7 @@ spring:
     port: 5672
     username: gridcapa
     password: gridcapa
+    virtual-host: gridcapa
   cloud:
     stream:
       default:

--- a/k8s/bases/common/gridcapa-rao-runner-configmap.yaml
+++ b/k8s/bases/common/gridcapa-rao-runner-configmap.yaml
@@ -13,6 +13,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/common/rabbitmq-configmap.yaml
+++ b/k8s/bases/common/rabbitmq-configmap.yaml
@@ -8,3 +8,4 @@ metadata:
 data:
   rabbitmq.conf: |-
     consumer_timeout = 86400000
+    default_vhost = gridcapa

--- a/k8s/bases/core-cc/core-cc-adapter-configmap.yaml
+++ b/k8s/bases/core-cc/core-cc-adapter-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 60000000
       cloud:

--- a/k8s/bases/core-cc/core-cc-gridcapa-job-launcher-configmap.yaml
+++ b/k8s/bases/core-cc/core-cc-gridcapa-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: core-cc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/core-cc/core-cc-gridcapa-post-processing-configmap.yml
+++ b/k8s/bases/core-cc/core-cc-gridcapa-post-processing-configmap.yml
@@ -18,9 +18,10 @@ data:
           name: core-cc-gridcapa-post-processing
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/core-cc/core-cc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/core-cc/core-cc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: core-cc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/core-cc/core-cc-runner-configmap.yaml
+++ b/k8s/bases/core-cc/core-cc-runner-configmap.yaml
@@ -16,9 +16,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/core-cc/core-cc-task-manager-configmap.yaml
+++ b/k8s/bases/core-cc/core-cc-task-manager-configmap.yaml
@@ -31,6 +31,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/core-valid/core-valid-adapter-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-adapter-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 60000000
       cloud:

--- a/k8s/bases/core-valid/core-valid-exporter-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/core-valid/core-valid-gridcapa-job-launcher-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-gridcapa-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: core-valid-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/core-valid/core-valid-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: core-valid-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/core-valid/core-valid-runner-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-runner-configmap.yaml
@@ -16,9 +16,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/core-valid/core-valid-task-manager-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-task-manager-configmap.yaml
@@ -31,6 +31,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-adapter-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-adapter-configmap.yaml
@@ -11,10 +11,11 @@ data:
   application.yml: |-
     spring:
       rabbitmq:
-        username: ${RABBITMQ_USER}
-        password: ${RABBITMQ_PASSWORD}
         host: gridcapa-rabbitmq
         port: 5672
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
         template:
           reply-timeout: 14400000
       cloud:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-exporter-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-export-d2cc-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-export-d2cc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-runner-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-runner-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-adapter-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-adapter-configmap.yaml
@@ -11,10 +11,11 @@ data:
   application.yml: |-
     spring:
       rabbitmq:
-        username: ${RABBITMQ_USER}
-        password: ${RABBITMQ_PASSWORD}
         host: gridcapa-rabbitmq
         port: 5672
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
         template:
           reply-timeout: 14400000
       cloud:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-exporter-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-export-idcc-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-export-idcc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-runner-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-runner-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-adapter-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-adapter-configmap.yaml
@@ -11,10 +11,11 @@ data:
   application.yml: |-
     spring:
       rabbitmq:
-        username: ${RABBITMQ_USER}
-        password: ${RABBITMQ_PASSWORD}
         host: gridcapa-rabbitmq
         port: 5672
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
         template:
           reply-timeout: 14400000
       cloud:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-exporter-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-import-d2cc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-d2cc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-runner-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-runner-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-d2cc-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-adapter-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-adapter-configmap.yaml
@@ -11,10 +11,11 @@ data:
   application.yml: |-
     spring:
       rabbitmq:
-        username: ${RABBITMQ_USER}
-        password: ${RABBITMQ_PASSWORD}
         host: gridcapa-rabbitmq
         port: 5672
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
         template:
           reply-timeout: 14400000
       cloud:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-exporter-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-import-ec-d2cc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-ec-d2cc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-runner-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-runner-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-ec-d2cc-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-adapter-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-adapter-configmap.yaml
@@ -11,10 +11,11 @@ data:
   application.yml: |-
     spring:
       rabbitmq:
-        username: ${RABBITMQ_USER}
-        password: ${RABBITMQ_PASSWORD}
         host: gridcapa-rabbitmq
         port: 5672
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
         template:
           reply-timeout: 14400000
       cloud:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-exporter-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-import-ec-idcc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-ec-idcc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-runner-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-runner-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-ec-idcc-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-adapter-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-adapter-configmap.yaml
@@ -11,10 +11,11 @@ data:
   application.yml: |-
     spring:
       rabbitmq:
-        username: ${RABBITMQ_USER}
-        password: ${RABBITMQ_PASSWORD}
         host: gridcapa-rabbitmq
         port: 5672
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
         template:
           reply-timeout: 14400000
       cloud:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-exporter-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-exporter-configmap.yaml
@@ -19,6 +19,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-import-idcc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-idcc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-runner-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-runner-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-import-idcc-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-adapter-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-adapter-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 60000000
       cloud:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-valid-d2cc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-publication-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-publication-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-valid-d2cc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-runner-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-runner-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-adapter-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-adapter-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 60000000
       cloud:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-job-launcher-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-job-launcher-configmap.yaml
@@ -18,9 +18,10 @@ data:
         name: cse-valid-idcc-gridcapa-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-publication-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-publication-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-rao-logs-dispatcher-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-rao-logs-dispatcher-configmap.yaml
@@ -14,9 +14,10 @@ data:
         name: cse-valid-idcc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-runner-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-runner-configmap.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-task-manager-configmap.yaml
@@ -29,6 +29,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-d2cc/swe-d2cc-adapter.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-adapter.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/swe-d2cc/swe-d2cc-exporter.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-exporter.yaml
@@ -17,6 +17,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-d2cc/swe-d2cc-job-launcher.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-job-launcher.yaml
@@ -18,9 +18,10 @@ data:
         name: swe-d2cc-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/swe-d2cc/swe-d2cc-rao-logs-dispatcher.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-rao-logs-dispatcher.yaml
@@ -14,9 +14,10 @@ data:
         name: swe-d2cc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-d2cc/swe-d2cc-runner.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-runner.yaml
@@ -14,9 +14,10 @@ data:
         name: swe-d2cc-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/swe-d2cc/swe-d2cc-task-manager.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-task-manager.yaml
@@ -31,6 +31,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-adapter.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-adapter.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-exporter.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-exporter.yaml
@@ -17,6 +17,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-job-launcher.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-job-launcher.yaml
@@ -18,9 +18,10 @@ data:
         name: swe-idcc-idcf-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-rao-logs-dispatcher.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-rao-logs-dispatcher.yaml
@@ -14,9 +14,10 @@ data:
         name: swe-idcc-idcf-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-runner.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-runner.yaml
@@ -14,9 +14,10 @@ data:
         name: swe-idcc-idcf-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-task-manager.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-task-manager.yaml
@@ -31,6 +31,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-idcc/swe-idcc-adapter.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-adapter.yaml
@@ -12,9 +12,10 @@ data:
     spring:
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/swe-idcc/swe-idcc-exporter.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-exporter.yaml
@@ -17,6 +17,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-idcc/swe-idcc-job-launcher.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-job-launcher.yaml
@@ -18,9 +18,10 @@ data:
         name: swe-idcc-job-launcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           bindings:

--- a/k8s/bases/swe-idcc/swe-idcc-rao-logs-dispatcher.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-rao-logs-dispatcher.yaml
@@ -14,9 +14,10 @@ data:
         name: swe-idcc-rao-logs-dispatcher
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
       cloud:
         stream:
           default:

--- a/k8s/bases/swe-idcc/swe-idcc-runner.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-runner.yaml
@@ -14,9 +14,10 @@ data:
         name: swe-idcc-runner
       rabbitmq:
         host: gridcapa-rabbitmq
+        port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
-        port: 5672
+        virtual-host: gridcapa
         template:
           reply-timeout: 7200000
       cloud:

--- a/k8s/bases/swe-idcc/swe-idcc-task-manager.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-task-manager.yaml
@@ -31,6 +31,7 @@ data:
         port: 5672
         username: ${RABBITMQ_USER}
         password: ${RABBITMQ_PASSWORD}
+        virtual-host: gridcapa
       cloud:
         stream:
           default:


### PR DESCRIPTION
Replace default vhost "/" in RabbitMQ configuration to allow access to the queues' detailed page on rabbit HMI.


**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
