### PR TITLE
Revert "[swe] put max-curative-ra-per-tso for RTE to 3"

### DIFF
--- a/configuration/prod/swe-runner-itools-config.yml
+++ b/configuration/prod/swe-runner-itools-config.yml
@@ -50,7 +50,7 @@ rao-second-preventive-rao:
 rao-ra-usage-limits-per-contingency:
   max-curative-ra: 10
   max-curative-tso: 2
-  max-curative-ra-per-tso: [ "{RTE}:3" ]
+  max-curative-ra-per-tso: [ "{RTE}:5" ]
 
 rao-not-optimized-cnecs:
   do-not-optimize-curative-cnecs-for-tsos-without-cras: false


### PR DESCRIPTION
Reverts farao-community/gridcapa-deployment#431

The fix is now available in https://github.com/farao-community/gridcapa-swe/blob/main/gridcapa-swe-runner-app/src/main/resources/crac/CimCracCreationParameters_FR-ES_D2CC.json 