### PR TITLE
Fix default timezone for timestamps in database

### DIFF
--- a/docker-compose/core-cc/config/core-cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/core-cc/config/core-cc-gridcapa-task-manager-application.yml
@@ -12,7 +12,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
   rabbitmq:
     host: rabbitmq
     port: 5672

--- a/docker-compose/core-valid/config/core-valid-gridcapa-task-manager-application.yml
+++ b/docker-compose/core-valid/config/core-valid-gridcapa-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-task-manager-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-task-manager-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-d2cc-gridcapa-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-import-ec-idcc/config/cse-idcc-task-manager-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-idcc-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-import-idcc/config/cse-idcc-task-manager-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-idcc-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-gridcapa-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-gridcapa-task-manager-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-gridcapa-task-manager-application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   rabbitmq:

--- a/docker-compose/swe-btcc/config/swe-btcc-task-manager-application.yml
+++ b/docker-compose/swe-btcc/config/swe-btcc-task-manager-application.yml
@@ -9,7 +9,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   sql:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-task-manager-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-task-manager-application.yml
@@ -9,7 +9,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   sql:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-task-manager-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-task-manager-application.yml
@@ -9,7 +9,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   sql:

--- a/docker-compose/swe-idcc/config/swe-idcc-task-manager-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-task-manager-application.yml
@@ -9,7 +9,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
     hibernate:
       ddl-auto: update
   sql:

--- a/k8s/bases/core-cc/core-cc-task-manager-configmap.yaml
+++ b/k8s/bases/core-cc/core-cc-task-manager-configmap.yaml
@@ -27,7 +27,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/core-valid/core-valid-task-manager-configmap.yaml
+++ b/k8s/bases/core-valid/core-valid-task-manager-configmap.yaml
@@ -27,7 +27,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-export-d2cc/cse-export-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-export-d2cc/cse-export-d2cc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-export-idcc/cse-export-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-export-idcc/cse-export-idcc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-import-d2cc/cse-import-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-d2cc/cse-import-d2cc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-ec-d2cc/cse-import-ec-d2cc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-ec-idcc/cse-import-ec-idcc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-import-idcc/cse-import-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-import-idcc/cse-import-idcc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-valid-d2cc/cse-valid-d2cc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/cse-valid-idcc/cse-valid-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/cse-valid-idcc/cse-valid-idcc-task-manager-configmap.yaml
@@ -25,7 +25,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       rabbitmq:

--- a/k8s/bases/swe-btcc/swe-btcc-task-manager-configmap.yaml
+++ b/k8s/bases/swe-btcc/swe-btcc-task-manager-configmap.yaml
@@ -26,7 +26,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         database-platform: org.hibernate.dialect.PostgreSQLDialect
         defer-datasource-initialization: true
         hibernate:

--- a/k8s/bases/swe-d2cc/swe-d2cc-task-manager-configmap.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-task-manager-configmap.yaml
@@ -26,7 +26,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         database-platform: org.hibernate.dialect.PostgreSQLDialect
         defer-datasource-initialization: true
         hibernate:

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-task-manager-configmap.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-task-manager-configmap.yaml
@@ -28,7 +28,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       sql:

--- a/k8s/bases/swe-idcc/swe-idcc-task-manager-configmap.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-task-manager-configmap.yaml
@@ -28,7 +28,7 @@ data:
         properties:
           hibernate:
             timezone:
-              default_storage: NORMALIZE
+              default_storage: NORMALIZE_UTC
         hibernate:
           ddl-auto: update
       sql:


### PR DESCRIPTION
Related to issues detailed there : https://thorben-janssen.com/hibernate-6-offsetdatetime-and-zoneddatetime/
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
