### PR TITLE
Set GridCapa version used by docker-compose in a single file

### DIFF
--- a/docker-compose/common/config/version.env
+++ b/docker-compose/common/config/version.env
@@ -1,0 +1,1 @@
+GRIDCAPA_VERSION=Docker-compose local

--- a/docker-compose/core-cc/config/core-cc-adapter-application.yml
+++ b/docker-compose/core-cc/config/core-cc-adapter-application.yml
@@ -38,7 +38,7 @@ minio-adapter:
   secret-key: gridcapa
   url: http://minio:9000
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 core-cc-adapter:
   auto-trigger-filetypes:

--- a/docker-compose/core-cc/docker-compose.yml
+++ b/docker-compose/core-cc/docker-compose.yml
@@ -45,6 +45,8 @@ services:
 
   core-cc-adapter:
     image: farao/gridcapa-core-cc-adapter:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/core-cc-adapter-application.yml:/config/application.yml
     healthcheck:

--- a/docker-compose/core-valid/config/core-valid-job-launcher-application.yml
+++ b/docker-compose/core-valid/config/core-valid-job-launcher-application.yml
@@ -35,7 +35,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/core-valid/docker-compose.yml
+++ b/docker-compose/core-valid/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   core-valid-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/core-valid-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-export-d2cc/config/cse-export-d2cc-job-launcher-application.yml
+++ b/docker-compose/cse-export-d2cc/config/cse-export-d2cc-job-launcher-application.yml
@@ -39,7 +39,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   auto: true

--- a/docker-compose/cse-export-d2cc/docker-compose.yml
+++ b/docker-compose/cse-export-d2cc/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   cse-export-d2cc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-export-d2cc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-export-idcc/config/cse-export-idcc-job-launcher-application.yml
+++ b/docker-compose/cse-export-idcc/config/cse-export-idcc-job-launcher-application.yml
@@ -39,7 +39,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   auto: true

--- a/docker-compose/cse-export-idcc/docker-compose.yml
+++ b/docker-compose/cse-export-idcc/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   cse-export-idcc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-export-idcc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-import-d2cc/config/cse-import-d2cc-job-launcher-application.yml
+++ b/docker-compose/cse-import-d2cc/config/cse-import-d2cc-job-launcher-application.yml
@@ -37,7 +37,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/cse-import-d2cc/docker-compose.yml
+++ b/docker-compose/cse-import-d2cc/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   cse-import-d2cc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-import-d2cc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-import-ec-d2cc/config/cse-import-ec-d2cc-job-launcher-application.yml
+++ b/docker-compose/cse-import-ec-d2cc/config/cse-import-ec-d2cc-job-launcher-application.yml
@@ -37,7 +37,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/cse-import-ec-idcc/config/cse-import-ec-idcc-job-launcher-application.yml
+++ b/docker-compose/cse-import-ec-idcc/config/cse-import-ec-idcc-job-launcher-application.yml
@@ -37,7 +37,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version : 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/cse-import-ec-idcc/docker-compose.yml
+++ b/docker-compose/cse-import-ec-idcc/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   cse-import-ec-idcc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-import-ec-idcc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-import-idcc/config/cse-import-idcc-job-launcher-application.yml
+++ b/docker-compose/cse-import-idcc/config/cse-import-idcc-job-launcher-application.yml
@@ -37,7 +37,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/cse-import-idcc/docker-compose.yml
+++ b/docker-compose/cse-import-idcc/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   cse-import-idcc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-import-idcc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-job-launcher-application.yml
+++ b/docker-compose/cse-valid-d2cc/config/cse-valid-d2cc-job-launcher-application.yml
@@ -33,7 +33,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/cse-valid-d2cc/docker-compose.yml
+++ b/docker-compose/cse-valid-d2cc/docker-compose.yml
@@ -72,6 +72,8 @@ services:
 
   cse-valid-d2cc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-valid-d2cc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/cse-valid-idcc/config/cse-valid-idcc-job-launcher-application.yml
+++ b/docker-compose/cse-valid-idcc/config/cse-valid-idcc-job-launcher-application.yml
@@ -33,7 +33,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/cse-valid-idcc/docker-compose.yml
+++ b/docker-compose/cse-valid-idcc/docker-compose.yml
@@ -72,6 +72,8 @@ services:
 
   cse-valid-idcc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/cse-valid-idcc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/swe-btcc/config/swe-btcc-job-launcher-application.yml
+++ b/docker-compose/swe-btcc/config/swe-btcc-job-launcher-application.yml
@@ -34,7 +34,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/swe-btcc/docker-compose.yml
+++ b/docker-compose/swe-btcc/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   swe-btcc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/swe-btcc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/swe-d2cc/config/swe-d2cc-job-launcher-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-job-launcher-application.yml
@@ -37,7 +37,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/swe-d2cc/docker-compose.yml
+++ b/docker-compose/swe-d2cc/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   swe-d2cc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/swe-d2cc-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-job-launcher-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-job-launcher-application.yml
@@ -34,7 +34,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/swe-idcc-idcf/docker-compose.yml
+++ b/docker-compose/swe-idcc-idcf/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   swe-idcc-idcf-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/swe-idcc-idcf-job-launcher-application.yml:/config/application.yml
     networks:

--- a/docker-compose/swe-idcc/config/swe-idcc-job-launcher-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-job-launcher-application.yml
@@ -34,7 +34,7 @@ spring:
             consumer:
               binding-routing-key: input
 
-gridcapa-version: 5.18.1
+gridcapa-version: ${GRIDCAPA_VERSION}
 
 job-launcher:
   url:

--- a/docker-compose/swe-idcc/docker-compose.yml
+++ b/docker-compose/swe-idcc/docker-compose.yml
@@ -25,6 +25,8 @@ services:
 
   swe-idcc-job-launcher:
     image: farao/gridcapa-job-launcher:latest
+    env_file:
+      - ../common/config/version.env
     volumes:
       - ./config/swe-idcc-job-launcher-application.yml:/config/application.yml
     networks:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized environment variable support for versioning across multiple Docker Compose services.
  * Enabled dynamic configuration of the gridcapa version via environment variables instead of hardcoded values.

* **Chores**
  * Updated service configurations to load environment variables from a shared version file, improving maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->