### PR TITLE
Remove workaround on remote voltage

### DIFF
--- a/docker-compose/swe-btcc/config/swe-btcc-runner-application.yml
+++ b/docker-compose/swe-btcc/config/swe-btcc-runner-application.yml
@@ -34,8 +34,6 @@ rao-runner-server:
     queue-name: rao-request-queue
 
 swe-runner:
-  data-fix:
-    remove-remote-voltage-regulation-in-france: true
   pst:
     pst-ids:
       - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/docker-compose/swe-d2cc/config/swe-d2cc-runner-application.yml
+++ b/docker-compose/swe-d2cc/config/swe-d2cc-runner-application.yml
@@ -37,8 +37,6 @@ rao-runner-server:
     queue-name: rao-request-queue
 
 swe-runner:
-  data-fix:
-    remove-remote-voltage-regulation-in-france: true
   pst:
     pst-ids:
       - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-runner-application.yml
+++ b/docker-compose/swe-idcc-idcf/config/swe-idcc-idcf-runner-application.yml
@@ -34,8 +34,6 @@ rao-runner-server:
     queue-name: rao-request-queue
 
 swe-runner:
-  data-fix:
-    remove-remote-voltage-regulation-in-france: true
   pst:
     pst-ids:
       - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/docker-compose/swe-idcc/config/swe-idcc-runner-application.yml
+++ b/docker-compose/swe-idcc/config/swe-idcc-runner-application.yml
@@ -36,8 +36,6 @@ rao-runner-server:
     queue-name: rao-request-queue
 
 swe-runner:
-  data-fix:
-    remove-remote-voltage-regulation-in-france: true
   pst:
     pst-ids:
       - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/k8s/bases/swe-btcc/swe-btcc-runner-configmap.yaml
+++ b/k8s/bases/swe-btcc/swe-btcc-runner-configmap.yaml
@@ -49,8 +49,6 @@ data:
         queue-name: rao-request-queue
 
     swe-runner:
-      data-fix:
-        remove-remote-voltage-regulation-in-france: true
       pst:
         pst-ids:
           - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/k8s/bases/swe-d2cc/swe-d2cc-runner-configmap.yaml
+++ b/k8s/bases/swe-d2cc/swe-d2cc-runner-configmap.yaml
@@ -49,8 +49,6 @@ data:
         queue-name: rao-request-queue
 
     swe-runner:
-      data-fix:
-        remove-remote-voltage-regulation-in-france: false
       pst:
         pst-ids:
           - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-runner-configmap.yaml
+++ b/k8s/bases/swe-idcc-idcf/swe-idcc-idcf-runner-configmap.yaml
@@ -49,8 +49,6 @@ data:
         queue-name: rao-request-queue
 
     swe-runner:
-      data-fix:
-        remove-remote-voltage-regulation-in-france: true
       pst:
         pst-ids:
           - _e071a1d4-fef5-1bd9-5278-d195c5597b6e

--- a/k8s/bases/swe-idcc/swe-idcc-runner-configmap.yaml
+++ b/k8s/bases/swe-idcc/swe-idcc-runner-configmap.yaml
@@ -48,8 +48,6 @@ data:
         queue-name: rao-request-queue
 
     swe-runner:
-      data-fix:
-        remove-remote-voltage-regulation-in-france: false
       pst:
         pst-ids:
           - _e071a1d4-fef5-1bd9-5278-d195c5597b6e


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Disabled the “remote voltage regulation in France” data-fix across all SWE runners, aligning behavior consistently across environments.
  - Operational impact: processing now occurs without this special adjustment; results may change where the data-fix previously applied.
  - No other configuration changes or new settings introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->