### PR TITLE
Make filestash ingress use gridcapa-tls secret

### DIFF
--- a/k8s/overlays/azure/test/gridcapa-ingress.yaml
+++ b/k8s/overlays/azure/test/gridcapa-ingress.yaml
@@ -537,7 +537,5 @@ spec:
   tls:
     - hosts:
         - gridcapa.farao-community.com
-      secretName: gridcapa-tls
-    - hosts:
         - filestash.farao-community.com
-      secretName: gridcapa-filestash-tls
+      secretName: gridcapa-tls


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined TLS configuration in the Azure test environment.
  * TLS now applies only to gridcapa.farao-community.com using the gridcapa-tls certificate.
  * Removed TLS entry for filestash.farao-community.com.
  * No changes to ingress rules or path mappings; traffic routing remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->